### PR TITLE
Added code to check if tm is running

### DIFF
--- a/check_time_machine_currency.sh
+++ b/check_time_machine_currency.sh
@@ -60,6 +60,12 @@ isMavericks=`echo $osVersion '< 10.9' | bc -l`
 if [ $isMavericks -eq 0 ]
 then
     # 10.9+ Check
+    tmIsRunning=`tmutil status | grep Running | awk '{print $3}' | awk -F';' '{print $1}'`
+    if [ "$tmIsRunning" == "1" ]
+    then
+        printf "OK - Time Machine is backing up on this Mac!\n"
+        exit 0
+    fi
     lastBackupDateString=`tmutil latestbackup | grep -E -o "[0-9]{4}-[0-9]{2}-[0-9]{2}-[0-9]{6}"`
 
     if [ "$lastBackupDateString" == "" ]


### PR DESCRIPTION
Added a check to see if the Time Machine is running. Otherwise the script returns a 'CRITICAL' state and reports that no backup has be performed. I'm sure there a better way to parse the output of tmutil. Also, this uses a command line switch for tmutil, 'status', that is not documented afaik.

Mark
