### PR TITLE
Updated with support for OS X Yosemite (10.10)

### DIFF
--- a/check_time_machine_currency.sh
+++ b/check_time_machine_currency.sh
@@ -54,7 +54,7 @@ then
 fi
 
 # Check to see if we're running Mavericks or Yosemite as Time Machine runs a little differently
-osVersion=`sw_vers -productVersion | grep -E -o "[0-9]?[0-9]+\.[0-9]?[0-9]"`
+osVersion=`sw_vers -productVersion | grep -E -o "[0-9]+\.[0-9]?[0-9]"`
 isMavericks=`echo $osVersion '< 10.9' | bc -l`
 isYosemite=`echo $osVersion '< 10.10' | bc -l`
 


### PR DESCRIPTION
This plugin failed once the machine was update to Yosemite. I've added support for Yosemite and tested with 10.10 and 10.9 machines. I had to edit the regex a bit to work for both 10.9 and 10.10.
